### PR TITLE
增加延时应对反扒，修复字符匹配的边界问题

### DIFF
--- a/util/RequestUtil.py
+++ b/util/RequestUtil.py
@@ -1,4 +1,5 @@
 import re
+import time
 from tqdm import tqdm
 import util.LoginUtil as Login
 import requests
@@ -62,6 +63,7 @@ def get_message(start, count):
             headers=headers,
             timeout=(5, 10)  # 设置连接超时为5秒，读取超时为10秒
         )
+        time.sleep(5)
     except requests.Timeout:
         print("请求超时")
         return None

--- a/util/ToolsUtil.py
+++ b/util/ToolsUtil.py
@@ -243,8 +243,8 @@ def get_content_from_split(content):
     return content_split[1].strip() if len(content_split) > 1 else content.strip()
 
 
-# 判断两个字符串是否存在互相包含的情况
+# 判断两个字符串是否相等
 def is_any_mutual_exist(str1, str2):
     str1 = get_content_from_split(str1)
     str2 = get_content_from_split(str2)
-    return str1 in str2 or str2 in str1
+    return str1 == str2


### PR DESCRIPTION
根据最新issue反馈，#231 #246 #248 #249 #251，TX已加反扒策略，需要适当delay以防止端口封禁，在get_message增加了5s延时 ，可以稳定爬取

另外，相互包含字符匹配策略并不严格（ToolsUtil.is_any_mutual_exist），存在已发说说内容为空的情况，导致已删除列表被替换。（另外举例，假如user_moments存在 ”谢谢“这样一条简短说说，便会导致texts中所有包含”谢谢“的记录被忽略掉）
