### PR TITLE
fix: 修复无法查询历史删除说说的bad case

### DIFF
--- a/main.py
+++ b/main.py
@@ -247,9 +247,8 @@ if __name__ == '__main__':
             if response is None or not hasattr(response, 'content'):
                 print(f"获取消息失败：第 {i} 批次，返回值为空或无效")
                 continue
-            content_bytes = response.content
-            detected_encoding = chardet.detect(content_bytes)['encoding']
-            message = content_bytes.decode(detected_encoding if detected_encoding else "utf-8")
+
+            message = response.text
 
             # 处理HTML数据
             html = Tools.process_old_html(message)


### PR DESCRIPTION
修复了无法查询历史删除说说的case
原因是 接口返回内容有改动，按照原来取content里的内容解析的时候会抛出异常
我看现在的历史说内容是在 text字段里。